### PR TITLE
Update to latest certmanager

### DIFF
--- a/config/certmanager/certificate.yaml
+++ b/config/certmanager/certificate.yaml
@@ -1,7 +1,7 @@
 # The following manifests contain a self-signed issuer CR and a certificate CR.
 # More document can be found at https://docs.cert-manager.io
 # WARNING: Targets CertManager v1.0. Check https://cert-manager.io/docs/installation/upgrading/ for breaking changes.
-apiVersion: cert-manager.io/v1alpha3
+apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: selfsigned-issuer
@@ -9,7 +9,7 @@ metadata:
 spec:
   selfSigned: {}
 ---
-apiVersion: cert-manager.io/v1alpha3
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: serving-cert # this name should match the one appeared in kustomizeconfig.yaml

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -57,7 +57,7 @@ vars:
     objref:
       kind: Certificate
       group: cert-manager.io
-      version: v1alpha3
+      version: v1
       name: serving-cert # this name should match the one in certificate.yaml
     fieldref:
       fieldpath: metadata.namespace
@@ -65,7 +65,7 @@ vars:
     objref:
       kind: Certificate
       group: cert-manager.io
-      version: v1alpha3
+      version: v1
       name: serving-cert # this name should match the one in certificate.yaml
   - name: SERVICE_NAMESPACE # namespace of the service
     objref:


### PR DESCRIPTION
At least on OpenShift 4.8 with certmanager 1.6 the apiversion is no longer v1alpha3, its stable now "v1". 